### PR TITLE
Fixed Thundra API key environment variable constant to

### DIFF
--- a/thundra/constants.go
+++ b/thundra/constants.go
@@ -4,5 +4,5 @@ const collectorUrl = "https://collector.thundra.io/api/monitor-datas"
 const DataFormatVersion = "1.0"
 
 //Thundra
-const thundraApiKey = "thundraApiKey"
+const thundraApiKey = "thundra_apiKey"
 const thundraLambdaPublishCloudwatchEnable = "thundra_lambda_publish_cloudwatch_enable"


### PR DESCRIPTION
 `thundra_apiKey` (from `thundraApiKey`) according to documentation https://docs.thundra.io/docs/configuration

Fixes #7 