### PR TITLE
Fix/clean up

### DIFF
--- a/metric/builder.go
+++ b/metric/builder.go
@@ -1,8 +1,6 @@
 package metric
 
 import (
-	"github.com/shirou/gopsutil/net"
-	"github.com/shirou/gopsutil/process"
 	"github.com/thundra-io/thundra-lambda-agent-go/plugin"
 )
 
@@ -77,30 +75,10 @@ func (b *builder) DisableNetStats() mBuilder {
 
 // Builds and returns the metric plugin that you can pass to a thundra object while building it using AddPlugin().
 func (b *builder) Build() *metric {
-	//Initialize with empty objects
-	var prevDiskStat *process.IOCountersStat
-	var prevNetStat *net.IOCountersStat
-	var proc *process.Process
-
-	if !b.disableDiskStats {
-		prevDiskStat = &process.IOCountersStat{}
-	}
-
-	if !b.disableNetStats {
-		prevNetStat = &net.IOCountersStat{}
-	}
-
-	if !b.disableCPUStats || !b.disableDiskStats || !b.disableHeapStats {
-		proc = plugin.GetThisProcess()
-	}
+	proc = plugin.GetThisProcess()
 
 	return &metric{
-		span: &metricSpan{
-			prevDiskStat: prevDiskStat,
-			prevNetStat:  prevNetStat,
-			process:      proc,
-		},
-
+		span:                  new(metricSpan),
 		disableGCStats:        b.disableGCStats,
 		disableHeapStats:      b.disableHeapStats,
 		disableGoroutineStats: b.disableGoroutineStats,

--- a/metric/builder.go
+++ b/metric/builder.go
@@ -25,10 +25,6 @@ type builder struct {
 	disableCPUStats       bool
 	disableDiskStats      bool
 	disableNetStats       bool
-	prevDiskStat          *process.IOCountersStat
-	prevNetStat           *net.IOCountersStat
-	process               *process.Process
-	pid                   string
 }
 
 // New initializes a new metric object which collects all types of metrics. If you want to disable a metric that
@@ -82,22 +78,28 @@ func (b *builder) DisableNetStats() mBuilder {
 // Builds and returns the metric plugin that you can pass to a thundra object while building it using AddPlugin().
 func (b *builder) Build() *metric {
 	//Initialize with empty objects
+	var prevDiskStat *process.IOCountersStat
+	var prevNetStat *net.IOCountersStat
+	var proc *process.Process
+
 	if !b.disableDiskStats {
-		b.prevDiskStat = &process.IOCountersStat{}
+		prevDiskStat = &process.IOCountersStat{}
 	}
 
 	if !b.disableNetStats {
-		b.prevNetStat = &net.IOCountersStat{}
+		prevNetStat = &net.IOCountersStat{}
 	}
 
 	if !b.disableCPUStats || !b.disableDiskStats || !b.disableHeapStats {
-		b.process = plugin.GetThisProcess()
+		proc = plugin.GetThisProcess()
 	}
 
 	return &metric{
-		prevDiskStat: b.prevDiskStat,
-		prevNetStat:  b.prevNetStat,
-		process:      b.process,
+		span: &metricSpan{
+			prevDiskStat: prevDiskStat,
+			prevNetStat:  prevNetStat,
+			process:      proc,
+		},
 
 		disableGCStats:        b.disableGCStats,
 		disableHeapStats:      b.disableHeapStats,

--- a/metric/builder_test.go
+++ b/metric/builder_test.go
@@ -11,9 +11,9 @@ func TestNewBuilder(t *testing.T) {
 	test.PrepareEnvironment()
 	m := NewBuilder().Build()
 
-	assert.NotNil(t, m.prevDiskStat)
-	assert.NotNil(t, m.prevNetStat)
-	assert.NotNil(t, m.process)
+	assert.NotNil(t, m.span.prevDiskStat)
+	assert.NotNil(t, m.span.prevNetStat)
+	assert.NotNil(t, m.span.process)
 
 	assert.False(t, m.disableDiskStats)
 	assert.False(t, m.disableNetStats)

--- a/metric/builder_test.go
+++ b/metric/builder_test.go
@@ -11,9 +11,8 @@ func TestNewBuilder(t *testing.T) {
 	test.PrepareEnvironment()
 	m := NewBuilder().Build()
 
-	assert.NotNil(t, m.span.prevDiskStat)
-	assert.NotNil(t, m.span.prevNetStat)
-	assert.NotNil(t, m.span.process)
+	assert.NotNil(t, m.span)
+	assert.NotNil(t, proc)
 
 	assert.False(t, m.disableDiskStats)
 	assert.False(t, m.disableNetStats)

--- a/metric/cpu.go
+++ b/metric/cpu.go
@@ -34,19 +34,19 @@ func prepareCPUStatsData(metric *metric) cpuStatsData {
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           cpuStat,
-		StatTimestamp:      metric.statTimestamp,
-		ProcessCPUPercent:  metric.processCpuPercent,
-		SystemCPUPercent:   metric.systemCpuPercent,
+		StatTimestamp:      metric.span.statTimestamp,
+		ProcessCPUPercent:  metric.span.processCpuPercent,
+		SystemCPUPercent:   metric.span.systemCpuPercent,
 	}
 }
 
 func getSystemUsagePercent(metric *metric) float64 {
 	// Skip test
-	if metric.startCPUTimeStat == nil {
+	if metric.span.startCPUTimeStat == nil {
 		return 0
 	}
-	dSysUsed := metric.endCPUTimeStat.sys_used() - metric.startCPUTimeStat.sys_used()
-	dTotal := metric.endCPUTimeStat.total() - metric.startCPUTimeStat.total()
+	dSysUsed := metric.span.endCPUTimeStat.sys_used() - metric.span.startCPUTimeStat.sys_used()
+	dTotal := metric.span.endCPUTimeStat.total() - metric.span.startCPUTimeStat.total()
 	s := float64(dSysUsed) / float64(dTotal)
 	if s <= 0 {
 		s = 0
@@ -60,11 +60,11 @@ func getSystemUsagePercent(metric *metric) float64 {
 
 func getProcessUsagePercent(metric *metric) float64 {
 	// Skip test
-	if metric.startCPUTimeStat == nil {
+	if metric.span.startCPUTimeStat == nil {
 		return 0
 	}
-	dProcUsed := metric.endCPUTimeStat.proc_used() - metric.startCPUTimeStat.proc_used()
-	dTotal := metric.endCPUTimeStat.total() - metric.startCPUTimeStat.total()
+	dProcUsed := metric.span.endCPUTimeStat.proc_used() - metric.span.startCPUTimeStat.proc_used()
+	dTotal := metric.span.endCPUTimeStat.total() - metric.span.startCPUTimeStat.total()
 	p := float64(dProcUsed) / float64(dTotal)
 	if p <= 0 {
 		p = 0

--- a/metric/cpu_test.go
+++ b/metric/cpu_test.go
@@ -12,5 +12,5 @@ func TestPrepareCPUStatsData(t *testing.T) {
 	cpuStatsData := prepareCPUStatsData(metric)
 
 	assert.Equal(t, cpuStat, cpuStatsData.StatName)
-	assert.Equal(t, metric.statTimestamp, cpuStatsData.StatTimestamp)
+	assert.Equal(t, metric.span.statTimestamp, cpuStatsData.StatTimestamp)
 }

--- a/metric/disk.go
+++ b/metric/disk.go
@@ -40,7 +40,7 @@ func prepareDiskStatsData(metric *metric) diskStatsData {
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           diskStat,
-		StatTimestamp:      metric.statTimestamp,
+		StatTimestamp:      metric.span.statTimestamp,
 
 		ReadBytes:  df.readBytes,
 		WriteBytes: df.writeBytes,
@@ -59,13 +59,13 @@ type diskFrame struct {
 //Since lambda works continuously we should subtract io values in order to get correct results per invocation
 //takeDiskFrame returns IO operations count for a specific time range
 func takeDiskFrame(metric *metric) *diskFrame {
-	rb := metric.currDiskStat.ReadBytes - metric.prevDiskStat.ReadBytes
-	wb := metric.currDiskStat.WriteBytes - metric.prevDiskStat.WriteBytes
+	rb := metric.span.currDiskStat.ReadBytes - metric.span.prevDiskStat.ReadBytes
+	wb := metric.span.currDiskStat.WriteBytes - metric.span.prevDiskStat.WriteBytes
 
-	rc := metric.currDiskStat.ReadCount - metric.prevDiskStat.ReadCount
-	wc := metric.currDiskStat.WriteCount - metric.prevDiskStat.WriteCount
+	rc := metric.span.currDiskStat.ReadCount - metric.span.prevDiskStat.ReadCount
+	wc := metric.span.currDiskStat.WriteCount - metric.span.prevDiskStat.WriteCount
 
-	metric.prevDiskStat = metric.currDiskStat
+	metric.span.prevDiskStat = metric.span.currDiskStat
 	return &diskFrame{
 		readBytes:  rb,
 		writeBytes: wb,

--- a/metric/gc.go
+++ b/metric/gc.go
@@ -51,14 +51,14 @@ func prepareGCStatsData(metric *metric, memStats *runtime.MemStats) gcStatsData 
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           gcStat,
-		StatTimestamp:      metric.statTimestamp,
+		StatTimestamp:      metric.span.statTimestamp,
 
 		PauseTotalNs:      memStats.PauseTotalNs,
 		PauseNs:           memStats.PauseNs[(memStats.NumGC+255)%256],
 		NumGC:             memStats.NumGC,
 		NextGC:            memStats.NextGC,
 		GCCPUFraction:     memStats.GCCPUFraction,
-		DeltaNumGc:        metric.endGCCount - metric.startGCCount,
-		DeltaPauseTotalNs: metric.endPauseTotalNs - metric.startPauseTotalNs,
+		DeltaNumGc:        metric.span.endGCCount - metric.span.startGCCount,
+		DeltaPauseTotalNs: metric.span.endPauseTotalNs - metric.span.startPauseTotalNs,
 	}
 }

--- a/metric/gc_test.go
+++ b/metric/gc_test.go
@@ -11,8 +11,8 @@ const numGC = 5
 
 func TestPrepareGCStatsData(t *testing.T) {
 	metric := NewBuilder().Build()
-	metric.startGCCount = 0
-	metric.endGCCount = numGC
+	metric.span.startGCCount = 0
+	metric.span.endGCCount = numGC
 
 	makeMultipleGCCalls(numGC)
 	memStats := &runtime.MemStats{}

--- a/metric/goroutine.go
+++ b/metric/goroutine.go
@@ -30,7 +30,7 @@ func prepareGoRoutineStatsData(metric *metric) goRoutineStatsData {
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           goroutineStat,
-		StatTimestamp:      metric.statTimestamp,
+		StatTimestamp:      metric.span.statTimestamp,
 		NumGoroutine:       uint64(runtime.NumGoroutine()),
 	}
 }

--- a/metric/goroutine_test.go
+++ b/metric/goroutine_test.go
@@ -15,9 +15,9 @@ const defaultGoroutines = 2
 
 func TestPrepareGoroutineStatsData(t *testing.T) {
 	metric := NewBuilder().Build()
-	metric.statTimestamp = plugin.GetTimestamp()
-	metric.startGCCount = 1
-	metric.endGCCount = 2
+	metric.span.statTimestamp = plugin.GetTimestamp()
+	metric.span.startGCCount = 1
+	metric.span.endGCCount = 2
 
 	done := make(chan bool)
 	generateGoroutines(done, numGoroutines)
@@ -25,7 +25,7 @@ func TestPrepareGoroutineStatsData(t *testing.T) {
 	gcStatsData := prepareGoRoutineStatsData(metric)
 
 	assert.Equal(t, goroutineStat, gcStatsData.StatName)
-	assert.Equal(t, metric.statTimestamp, gcStatsData.StatTimestamp)
+	assert.Equal(t, metric.span.statTimestamp, gcStatsData.StatTimestamp)
 
 	assert.Equal(t, uint64(numGoroutines+defaultGoroutines), gcStatsData.NumGoroutine)
 	killGeneratedGoroutines(done, numGoroutines)

--- a/metric/heap.go
+++ b/metric/heap.go
@@ -43,7 +43,7 @@ type heapStatsData struct {
 }
 
 func prepareHeapStatsData(metric *metric, memStats *runtime.MemStats) heapStatsData {
-	mp, err := metric.span.process.MemoryPercent()
+	mp, err := proc.MemoryPercent()
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/metric/heap.go
+++ b/metric/heap.go
@@ -43,7 +43,7 @@ type heapStatsData struct {
 }
 
 func prepareHeapStatsData(metric *metric, memStats *runtime.MemStats) heapStatsData {
-	mp, err := metric.process.MemoryPercent()
+	mp, err := metric.span.process.MemoryPercent()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -57,7 +57,7 @@ func prepareHeapStatsData(metric *metric, memStats *runtime.MemStats) heapStatsD
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           heapStat,
-		StatTimestamp:      metric.statTimestamp,
+		StatTimestamp:      metric.span.statTimestamp,
 
 		HeapAlloc:     memStats.HeapAlloc,
 		HeapSys:       memStats.HeapSys,

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -16,8 +16,8 @@ func TestMetric_BeforeExecution(t *testing.T) {
 	const MaxUint64 = ^uint64(0)
 
 	m := NewBuilder().Build()
-	m.startGCCount = MaxUint32
-	m.startPauseTotalNs = MaxUint64
+	m.span.startGCCount = MaxUint32
+	m.span.startPauseTotalNs = MaxUint64
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -26,8 +26,8 @@ func TestMetric_BeforeExecution(t *testing.T) {
 	// In order to ensure startGCCount and startPauseTotalNs are assigned,
 	// check it's initial value is changed.
 	// Initial values are the maximum numbers to eliminate unlucky conditions from happenning.
-	assert.NotEqual(t, MaxUint32, m.startGCCount)
-	assert.NotEqual(t, MaxUint64, m.startPauseTotalNs)
+	assert.NotEqual(t, MaxUint32, m.span.startGCCount)
+	assert.NotEqual(t, MaxUint64, m.span.startPauseTotalNs)
 }
 
 func TestMetric_AfterExecution(t *testing.T) {
@@ -35,8 +35,8 @@ func TestMetric_AfterExecution(t *testing.T) {
 	const MaxUint64 = ^uint64(0)
 
 	m := NewBuilder().Build()
-	m.endGCCount = MaxUint32
-	m.endPauseTotalNs = MaxUint64
+	m.span.endGCCount = MaxUint32
+	m.span.endPauseTotalNs = MaxUint64
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -51,9 +51,9 @@ func TestMetric_AfterExecution(t *testing.T) {
 	// In order to ensure endGCCount and endPauseTotalNs are assigned,
 	// check it's initial value is changed.
 	// Initial values are the maximum numbers to eliminate unlucky conditions from happenning.
-	assert.NotEqual(t, MaxUint32, m.endGCCount)
-	assert.NotEqual(t, MaxUint64, m.endPauseTotalNs)
+	assert.NotEqual(t, MaxUint32, m.span.endGCCount)
+	assert.NotEqual(t, MaxUint64, m.span.endPauseTotalNs)
 
-	assert.True(t, m.statTimestamp <= plugin.GetTimestamp())
+	assert.True(t, m.span.statTimestamp <= plugin.GetTimestamp())
 	assert.Equal(t, statDataType, dataType)
 }

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/thundra-io/thundra-lambda-agent-go/plugin"
 	"runtime"
 )
 
@@ -22,6 +21,7 @@ func TestMetric_BeforeExecution(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	m.BeforeExecution(context.TODO(), json.RawMessage{}, &wg)
+	assert.NotNil(t, m.span)
 
 	// In order to ensure startGCCount and startPauseTotalNs are assigned,
 	// check it's initial value is changed.
@@ -31,12 +31,8 @@ func TestMetric_BeforeExecution(t *testing.T) {
 }
 
 func TestMetric_AfterExecution(t *testing.T) {
-	const MaxUint32 = ^uint32(0)
-	const MaxUint64 = ^uint64(0)
 
 	m := NewBuilder().Build()
-	m.span.endGCCount = MaxUint32
-	m.span.endPauseTotalNs = MaxUint64
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -48,12 +44,6 @@ func TestMetric_AfterExecution(t *testing.T) {
 		assert.Equal(t, 6, len(stats))
 	}
 
-	// In order to ensure endGCCount and endPauseTotalNs are assigned,
-	// check it's initial value is changed.
-	// Initial values are the maximum numbers to eliminate unlucky conditions from happenning.
-	assert.NotEqual(t, MaxUint32, m.span.endGCCount)
-	assert.NotEqual(t, MaxUint64, m.span.endPauseTotalNs)
-
-	assert.True(t, m.span.statTimestamp <= plugin.GetTimestamp())
+	assert.Nil(t, m.span)
 	assert.Equal(t, statDataType, dataType)
 }

--- a/metric/net.go
+++ b/metric/net.go
@@ -1,7 +1,10 @@
 package metric
 
 import (
+	"fmt"
+
 	"github.com/thundra-io/thundra-lambda-agent-go/plugin"
+	"github.com/shirou/gopsutil/net"
 )
 
 const all = 0
@@ -70,14 +73,18 @@ type netFrame struct {
 
 //Since lambda works continuously we should subtract io values in order to get correct results per invocation
 func takeNetFrame(metric *metric) *netFrame {
-	br := metric.span.currNetStat.BytesRecv - metric.span.prevNetStat.BytesRecv
-	bs := metric.span.currNetStat.BytesSent - metric.span.prevNetStat.BytesSent
-	ps := metric.span.currNetStat.PacketsSent - metric.span.prevNetStat.PacketsSent
-	pr := metric.span.currNetStat.PacketsRecv - metric.span.prevNetStat.PacketsRecv
-	ei := metric.span.currNetStat.Errin - metric.span.prevNetStat.Errin
-	eo := metric.span.currNetStat.Errout - metric.span.prevNetStat.Errout
+	// If nil, return an empty netFrame
+	if metric.span.endNetStat == nil || metric.span.startNetStat == nil {
+		return &netFrame{}
+	}
 
-	metric.span.prevNetStat = metric.span.currNetStat
+	br := metric.span.endNetStat.BytesRecv - metric.span.startNetStat.BytesRecv
+	bs := metric.span.endNetStat.BytesSent - metric.span.startNetStat.BytesSent
+	ps := metric.span.endNetStat.PacketsSent - metric.span.startNetStat.PacketsSent
+	pr := metric.span.endNetStat.PacketsRecv - metric.span.startNetStat.PacketsRecv
+	ei := metric.span.endNetStat.Errin - metric.span.startNetStat.Errin
+	eo := metric.span.endNetStat.Errout - metric.span.startNetStat.Errout
+
 	return &netFrame{
 		bytesRecv:   br,
 		bytesSent:   bs,
@@ -86,4 +93,13 @@ func takeNetFrame(metric *metric) *netFrame {
 		errin:       ei,
 		errout:      eo,
 	}
+}
+
+func sampleNetStat() (*net.IOCountersStat) {
+	netIOStat, err := net.IOCounters(false)
+	if err != nil {
+		fmt.Println("Error sampling net stat", err)
+		return nil
+	}
+	return &netIOStat[all]
 }

--- a/metric/net.go
+++ b/metric/net.go
@@ -48,7 +48,7 @@ func prepareNetStatsData(metric *metric) netStatsData {
 		ApplicationProfile: plugin.ApplicationProfile,
 		ApplicationType:    plugin.ApplicationType,
 		StatName:           netStat,
-		StatTimestamp:      metric.statTimestamp,
+		StatTimestamp:      metric.span.statTimestamp,
 
 		BytesRecv:   nf.bytesRecv,
 		BytesSent:   nf.bytesSent,
@@ -70,14 +70,14 @@ type netFrame struct {
 
 //Since lambda works continuously we should subtract io values in order to get correct results per invocation
 func takeNetFrame(metric *metric) *netFrame {
-	br := metric.currNetStat.BytesRecv - metric.prevNetStat.BytesRecv
-	bs := metric.currNetStat.BytesSent - metric.prevNetStat.BytesSent
-	ps := metric.currNetStat.PacketsSent - metric.prevNetStat.PacketsSent
-	pr := metric.currNetStat.PacketsRecv - metric.prevNetStat.PacketsRecv
-	ei := metric.currNetStat.Errin - metric.prevNetStat.Errin
-	eo := metric.currNetStat.Errout - metric.prevNetStat.Errout
+	br := metric.span.currNetStat.BytesRecv - metric.span.prevNetStat.BytesRecv
+	bs := metric.span.currNetStat.BytesSent - metric.span.prevNetStat.BytesSent
+	ps := metric.span.currNetStat.PacketsSent - metric.span.prevNetStat.PacketsSent
+	pr := metric.span.currNetStat.PacketsRecv - metric.span.prevNetStat.PacketsRecv
+	ei := metric.span.currNetStat.Errin - metric.span.prevNetStat.Errin
+	eo := metric.span.currNetStat.Errout - metric.span.prevNetStat.Errout
 
-	metric.prevNetStat = metric.currNetStat
+	metric.span.prevNetStat = metric.span.currNetStat
 	return &netFrame{
 		bytesRecv:   br,
 		bytesSent:   bs,

--- a/test/util.go
+++ b/test/util.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"sync/atomic"
+
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/stretchr/testify/mock"
 	"github.com/thundra-io/thundra-lambda-agent-go/plugin"
@@ -21,6 +23,7 @@ const (
 type MockReporter struct {
 	mock.Mock
 	MessageQueue []interface{}
+	ReportedFlag *uint32
 }
 
 func (r *MockReporter) Collect(messages []interface{}) {
@@ -30,10 +33,30 @@ func (r *MockReporter) Collect(messages []interface{}) {
 
 func (r *MockReporter) Report(apiKey string) {
 	r.Called(apiKey)
+	atomic.CompareAndSwapUint32(r.ReportedFlag, 0, 1)
 }
 
-func (r *MockReporter) Clear() {
+func (r *MockReporter) ClearData() {
 	r.Called()
+}
+
+func (r *MockReporter) Reported() *uint32 {
+	return r.ReportedFlag
+}
+
+func (r *MockReporter) FlushFlag() {
+	atomic.CompareAndSwapUint32(r.Reported(), 1, 0)
+}
+
+// NewMockReporter returns a new MockReporter
+func NewMockReporter(testApiKey string) *MockReporter {
+	r := &MockReporter{
+		ReportedFlag: new(uint32),
+	}
+	r.On("Report", testApiKey).Return()
+	r.On("ClearData").Return()
+	r.On("Collect", mock.Anything).Return()
+	return r
 }
 
 func PrepareEnvironment() {

--- a/thundra/builder.go
+++ b/thundra/builder.go
@@ -69,7 +69,9 @@ func (b *builder) Build() *thundra {
 	// Invocation is the default plugin
 	b.AddPlugin(invocation.New())
 	if b.reporter == nil {
-		b.reporter = &reporterImpl{}
+		b.reporter = &reporterImpl{
+			reported: new(uint32),
+		}
 	}
 
 	k := determineApiKey(b.apiKey)

--- a/thundra/wrapper_test.go
+++ b/thundra/wrapper_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/thundra-io/thundra-lambda-agent-go/test"
 )
 
@@ -116,11 +115,7 @@ func TestWrapper(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
-			r := &test.MockReporter{}
-			r.On("Report", testApiKey).Return()
-			r.On("Clear").Return()
-			r.On("Collect", mock.Anything).Return()
-
+			r := test.NewMockReporter(testApiKey)
 			th := NewBuilder().SetReporter(r).SetAPIKey(testApiKey).Build()
 			lambdaHandler := Wrap(testCase.handler, th)
 			h := lambdaHandler.(func(context.Context, json.RawMessage) (interface{}, error))
@@ -198,11 +193,7 @@ func TestInvalidWrappers(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
-			r := &test.MockReporter{}
-			r.On("Report", testApiKey).Return()
-			r.On("Clear").Return()
-			r.On("Collect", mock.Anything).Return()
-
+			r := test.NewMockReporter(testApiKey)
 			th := NewBuilder().SetReporter(r).SetAPIKey(testApiKey).Build()
 			lambdaHandler := Wrap(testCase.handler, th)
 			h, ok := lambdaHandler.(lambdaFunction)

--- a/trace/data.go
+++ b/trace/data.go
@@ -42,12 +42,12 @@ func (tr *trace) prepareTraceData(ctx context.Context, request json.RawMessage, 
 		ContextId:          plugin.ContextId,
 		ContextName:        plugin.ApplicationName,
 		ContextType:        executionContext,
-		StartTimestamp:     tr.startTime,
-		EndTimestamp:       tr.endTime,
-		Duration:           tr.duration,
-		Errors:             tr.errors,
-		ThrownError:        tr.thrownError,
-		ThrownErrorMessage: tr.thrownErrorMessage,
+		StartTimestamp:     tr.span.startTime,
+		EndTimestamp:       tr.span.endTime,
+		Duration:           tr.span.duration,
+		Errors:             tr.span.errors,
+		ThrownError:        tr.span.thrownError,
+		ThrownErrorMessage: tr.span.thrownErrorMessage,
 		AuditInfo:          ai,
 		Properties:         props,
 	}
@@ -76,7 +76,7 @@ func (tr *trace) prepareProperties(ctx context.Context, request json.RawMessage,
 		auditInfoPropertiesFunctionMemoryLimit: plugin.MemorySize,
 		auditInfoPropertiesFunctionARN:         plugin.GetInvokedFunctionArn(ctx),
 		auditInfoPropertiesRequestId:           plugin.GetAwsRequestID(ctx),
-		auditInfoPropertiesTimeout:             tr.timeout,
+		auditInfoPropertiesTimeout:             tr.span.timeout,
 	}
 }
 
@@ -84,12 +84,12 @@ func (tr *trace) prepareAuditInfo() map[string]interface{} {
 	var auditErrors []interface{}
 	var auditThrownError interface{}
 
-	if tr.panicInfo != nil {
-		p := *tr.panicInfo
+	if tr.span.panicInfo != nil {
+		p := *tr.span.panicInfo
 		auditErrors = append(auditErrors, p)
 		auditThrownError = p
-	} else if tr.errorInfo != nil {
-		e := *tr.errorInfo
+	} else if tr.span.errorInfo != nil {
+		e := *tr.span.errorInfo
 		auditErrors = append(auditErrors, e)
 		auditThrownError = e
 	}
@@ -97,8 +97,8 @@ func (tr *trace) prepareAuditInfo() map[string]interface{} {
 	return map[string]interface{}{
 		auditInfoContextName:    plugin.ApplicationName,
 		auditInfoId:             plugin.ContextId,
-		auditInfoOpenTimestamp:  tr.startTime,
-		auditInfoCloseTimestamp: tr.endTime,
+		auditInfoOpenTimestamp:  tr.span.startTime,
+		auditInfoCloseTimestamp: tr.span.endTime,
 		auditInfoErrors:         auditErrors,
 		auditInfoThrownError:    auditThrownError,
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -12,7 +12,7 @@ type trace struct {
 	span *traceSpan
 }
 
-// traceSpan is used by plugin to collect span based information
+// traceSpan collects information related to trace plugin per invocation.
 type traceSpan struct {
 	startTime          int64
 	endTime            int64

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -9,6 +9,11 @@ import (
 )
 
 type trace struct {
+	span *traceSpan
+}
+
+// traceSpan is used by plugin to collect span based information
+type traceSpan struct {
 	startTime          int64
 	endTime            int64
 	duration           int64
@@ -24,19 +29,19 @@ var invocationCount uint32
 
 // New returns a new trace object.
 func New() *trace {
-	return &trace{}
+	return new(trace)
 }
 
 func (tr *trace) BeforeExecution(ctx context.Context, request json.RawMessage, wg *sync.WaitGroup) {
-	cleanBuffer(tr)
-	tr.startTime = plugin.GetTimestamp()
+	tr.span = new(traceSpan)
+	tr.span.startTime = plugin.GetTimestamp()
 	plugin.GenerateNewContextId()
 	wg.Done()
 }
 
 func (tr *trace) AfterExecution(ctx context.Context, request json.RawMessage, response interface{}, err interface{}) ([]interface{}, string) {
-	tr.endTime = plugin.GetTimestamp()
-	tr.duration = tr.endTime - tr.startTime
+	tr.span.endTime = plugin.GetTimestamp()
+	tr.span.duration = tr.span.endTime - tr.span.startTime
 
 	if err != nil {
 		errMessage := plugin.GetErrorMessage(err)
@@ -47,23 +52,25 @@ func (tr *trace) AfterExecution(ctx context.Context, request json.RawMessage, re
 			errType,
 		}
 
-		tr.errorInfo = ei
-		tr.thrownError = errType
-		tr.thrownErrorMessage = errMessage
-		tr.errors = append(tr.errors, errType)
+		tr.span.errorInfo = ei
+		tr.span.thrownError = errType
+		tr.span.thrownErrorMessage = errMessage
+		tr.span.errors = append(tr.span.errors, errType)
 	}
 
-	tr.timeout = isTimeout(err)
+	tr.span.timeout = isTimeout(err)
 
 	td := tr.prepareTraceData(ctx, request, response)
+	tr.span = nil
+
 	var traceArr []interface{}
 	traceArr = append(traceArr, td)
 	return traceArr, traceDataType
 }
 
 func (tr *trace) OnPanic(ctx context.Context, request json.RawMessage, err interface{}, stackTrace []byte) ([]interface{}, string) {
-	tr.endTime = plugin.GetTimestamp()
-	tr.duration = tr.endTime - tr.startTime
+	tr.span.endTime = plugin.GetTimestamp()
+	tr.span.duration = tr.span.endTime - tr.span.startTime
 
 	errMessage := plugin.GetErrorMessage(err)
 	errType := plugin.GetErrorType(err)
@@ -73,22 +80,20 @@ func (tr *trace) OnPanic(ctx context.Context, request json.RawMessage, err inter
 		errType,
 	}
 
-	tr.panicInfo = pi
-	tr.thrownError = errType
-	tr.thrownErrorMessage = plugin.GetErrorMessage(err)
-	tr.errors = append(tr.errors, errType)
+	tr.span.panicInfo = pi
+	tr.span.thrownError = errType
+	tr.span.thrownErrorMessage = plugin.GetErrorMessage(err)
+	tr.span.errors = append(tr.span.errors, errType)
 
 	// since it is panicked it could not be timed out
-	tr.timeout = "false"
+	tr.span.timeout = "false"
 
 	td := tr.prepareTraceData(ctx, request, nil)
+	tr.span = nil
+
 	var traceArr []interface{}
 	traceArr = append(traceArr, td)
 	return traceArr, traceDataType
-}
-
-func cleanBuffer(trace *trace) {
-	trace.errors = nil
 }
 
 // isTimeout returns if the lambda invocation is timed out.

--- a/trace/trace_integration_test.go
+++ b/trace/trace_integration_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/thundra-io/thundra-lambda-agent-go/plugin"
 	"github.com/thundra-io/thundra-lambda-agent-go/test"
 	"github.com/thundra-io/thundra-lambda-agent-go/thundra"
@@ -107,11 +105,7 @@ func TestTrace(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
 			test.PrepareEnvironment()
 
-			r := new(test.MockReporter)
-			r.On("Report", testApiKey).Return()
-			r.On("Clear").Return()
-			r.On("Collect", mock.Anything).Return()
-
+			r := test.NewMockReporter(testApiKey)
 			tr := New()
 			th := thundra.NewBuilder().AddPlugin(tr).SetReporter(r).SetAPIKey(testApiKey).Build()
 			lambdaHandler := thundra.Wrap(testCase.handler, th)
@@ -240,11 +234,7 @@ func TestPanic(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase[%d] %s", i, testCase.name), func(t *testing.T) {
 			test.PrepareEnvironment()
 
-			r := new(test.MockReporter)
-			r.On("Report", testApiKey).Return()
-			r.On("Clear").Return()
-			r.On("Collect", mock.Anything).Return()
-
+			r := test.NewMockReporter(testApiKey)
 			tr := New()
 			th := thundra.NewBuilder().AddPlugin(tr).SetReporter(r).SetAPIKey(testApiKey).Build()
 			lambdaHandler := thundra.Wrap(testCase.handler, th)
@@ -349,11 +339,7 @@ func TestTimeout(t *testing.T) {
 	t.Run(fmt.Sprintf("testCase[%d] %s", 0, testCase[0].name), func(t *testing.T) {
 		test.PrepareEnvironment()
 
-		r := new(test.MockReporter)
-		r.On("Report", testApiKey).Return()
-		r.On("Clear").Return()
-		r.On("Collect", mock.Anything).Return()
-
+		r := test.NewMockReporter(testApiKey)
 		tr := New()
 		th := thundra.NewBuilder().AddPlugin(tr).SetReporter(r).SetAPIKey(testApiKey).Build()
 		lambdaHandler := thundra.Wrap(testCase[0].handler, th)


### PR DESCRIPTION
* Clean data before and after an invocation
* Changed reporter to skip after hooks if it is already sent to prevent timeouts
* Refactor reporter tests according to new reporter usage
* Introduced metricSpan to collect metric specific data per invocation
* Refactored disk and net data collection to clear metric data on start